### PR TITLE
Fix `38` icon variant

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
   "icons": {
     "16": "appicons/icon16.png",
     "19": "appicons/icon19.png",
-    "48": "appicons/icon38.png",
+    "38": "appicons/icon38.png",
     "48": "appicons/icon48.png",
     "128": "appicons/icon128.png"
   },


### PR DESCRIPTION
A typo removed the `appicons/icon38.png` icon size from being used.