### PR TITLE
Add Build Command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ nohup.out
 Thumbs.db
 
 node_modules
+build/*
+!build/.gitkeep

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "npm": "8.19.2"
   },
   "scripts": {
+    "build:extension": "zip -r build/extension.zip ./ -x './build/*' -x './node_modules/*' -x './.git/*'",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "format:check": "prettier --list-different  .",


### PR DESCRIPTION
This adds a new `npm run build:extension` command to generate `builds/extension.zip` meant for deployment to the Chrome Webstore. In the future, we can automate this with a Github Action.