### PR TITLE
Fix sites using `scrollbar-*` CSS

### DIFF
--- a/js/utils/getCompiledCSS.js
+++ b/js/utils/getCompiledCSS.js
@@ -23,6 +23,14 @@ export const getCompiledCSS = (scrollbarStyles) => {
 
   // Build our CSS structure as JSON for readability and maintainability. Then, we'll convert it to CSS!
   const rootJsonStyle = {
+    '*': {
+      attributes: {
+        'scrollbar-width': `unset`,
+        'scrollbar-color': 'unset',
+        'scrollbar-gutter': 'unset',
+      },
+    },
+
     '::-webkit-scrollbar, ::-webkit-scrollbar:horizontal, ::-webkit-scrollbar:vertical':
       {
         attributes: {


### PR DESCRIPTION
This fixes Rescroller on sites that have implemented their own styled scrollbars with [`scrollbar-width`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-width), [`scrollbar-color`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-color), and [`scrollbar-gutter`](https://developer.mozilla.org/en-US/docs/Web/CSS/scrollbar-gutter) CSS (such as YouTube as reported in #5).